### PR TITLE
Allow multi-line contact info.

### DIFF
--- a/my-resume.cls
+++ b/my-resume.cls
@@ -297,7 +297,18 @@
 % contact info
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\newcommand{\infofield}[2]{\mbox{\makebox[5mm]{\textcolor{accent}{\normalsize #1}}\hspace{0.5em}#2}\vspace{0.2em}\newline}
+\newcommand{\infofield}[2]{%
+        \begin{minipage}[t]{\linewidth}%
+            \begin{minipage}[t]{5mm}% wrap marker in minipage to allow multi-line contact info
+                \makebox[5mm][c]{\textcolor{accent}{\normalsize #1}}
+            \end{minipage}%
+            \hspace{0.5em}%
+            \begin{minipage}[t]{\dimexpr \linewidth-5mm-0.5em}% wrap info in minipage to allow multi-line info
+                #2
+            \end{minipage}%
+        \end{minipage}%
+        \vspace{0.2em}\newline
+}
 \newcommand{\email}[1]{\infofield{\faEnvelope}{\href{mailto:#1}{#1}}}
 \newcommand{\address}[1]{\infofield{\faAt}{#1}}
 \newcommand{\location}[1]{\infofield{\faMapMarker}{#1}}


### PR DESCRIPTION
Hi. First of all, thanks for publishing this template, I like it very much.
Since many people (and I think now more than ever) are digital nomads or are working for offshore companies, it's important to write a full address in the contact info section. Currently due to the usage of `makebox` only one line of text is allowed, which is not enough for most addresses if you need to include the state/province and country. To sort out this restriction I changed the `infofield` command to do something similar to the `job` command, so now you can put multi-line text and it's typeset properly aligned.
To check nothing else broke, I processed the original file with the updated class and it yields almost exactly the same result. I'm using LuaLaTeX 1.13.2 though, not XeLaTeX (BTW just to let you know, the template works fine with it).
I'm creating this PR just in case you consider this change useful. If you see my resume, you'd know I'm not very proficient in LaTeX, so feel free to make any modifications you deem necessary.

Regards.